### PR TITLE
Fix basic authentication.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function OpenHABPlatform(log, config){
     this.log      = log;
     this.user     = config["user"];
     this.password = config["password"];
-    this.host   = config["host"];
+    this.host     = config["host"];
     this.port     = config["port"];
     this.protocol = "http";
     this.sitemap  = "demo";

--- a/items/AbstractItem.js
+++ b/items/AbstractItem.js
@@ -20,6 +20,11 @@ var AbstractItem = function(widget,platform,homebridge) {
     this.listener = undefined;
     this.ws = undefined;
 
+    if (platform.user && platform.password) {
+	this.url = this.url.replace('http://', 'http://' + encodeURIComponent(this.platform.user) + ":"
+				    + encodeURIComponent(this.platform.password) + "@");
+    }
+
     this.name = this.platform.useLabelForName ? this.label : this.widget.name;
 
     AbstractItem.super_.call(this, this.name, homebridge.hap.uuid.generate(String(this.widget.name)));

--- a/libs/ItemFactory.js
+++ b/libs/ItemFactory.js
@@ -24,7 +24,7 @@ exports.Factory.prototype.sitemapUrl = function () {
     var serverString = this.platform.host;
     //TODO da verificare
     if (this.platform.user && this.platform.password) {
-        serverString = this.platform.user + ":" + this.platform.password + "@" + serverString;
+        serverString = encodeURIComponent(this.platform.user) + ":" + encodeURIComponent(this.platform.password) + "@" + serverString;
     }
 
     return this.platform.protocol + "://" + serverString + ":" + this.platform.port + "/rest/sitemaps/" + this.platform.sitemap + "?type=json";


### PR DESCRIPTION
The username and password need to be URL encoded.
Also, the returned item urls need to have the username
and password inserted into them.
